### PR TITLE
fix(core): pass the hono context into websocket functions

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -183,14 +183,20 @@ export type WSStatusCode =
  * rate-limited.
  *
  * @param context {Context} - The Hono context object.
- * @param next {Next} - The Hono `next` function, can be called to skip responding.
+ * @param event {unknown} - The WebSocket event that triggered the rate limit.
+ * @param ws {WSContext} - The Honos WebSocket context object.
  * @param optionsUsed {ConfigType} - The options used to set up the middleware.
  */
 export type WSRateLimitExceededEventHandler<
   E extends Env = Env,
   P extends string = string,
   I extends Input = Input,
-> = (event: unknown, ws: WSContext, optionsUsed: WSConfigType<E, P, I>) => void;
+> = (
+  c: Context<E, P, I>,
+  event: unknown,
+  ws: WSContext,
+  optionsUsed: WSConfigType<E, P, I>,
+) => void;
 
 /**
  * The configuration options for the rate limiter.
@@ -235,7 +241,11 @@ export interface WSConfigType<
    *
    * By default, skips no requests.
    */
-  skip: (event: unknown, ws: WSContext) => Promisify<boolean>;
+  skip: (
+    c: Context<E, P, I>,
+    event: unknown,
+    ws: WSContext,
+  ) => Promisify<boolean>;
 }
 
 export type IncrementResponse = ClientRateLimitInfo;

--- a/packages/core/src/websocket.ts
+++ b/packages/core/src/websocket.ts
@@ -34,7 +34,7 @@ export function webSocketLimiter<
     skipSuccessfulRequests = false,
     keyGenerator,
     skip = () => false,
-    handler = async (_, ws, options) =>
+    handler = async (_c, _event, ws, options) =>
       ws.close(options.statusCode, options.message),
     store = new MemoryStore<E, P, I>(),
   } = config;
@@ -67,7 +67,7 @@ export function webSocketLimiter<
         ...events,
         onMessage: async (event, ws) => {
           // First check if we should skip the request
-          const isSkippable = await skip(event, ws);
+          const isSkippable = await skip(c, event, ws);
 
           if (isSkippable) {
             await events.onMessage?.(event, ws);
@@ -119,7 +119,7 @@ export function webSocketLimiter<
           // If the client has exceeded their rate limit call the `handler` function.
           if (totalHits > _limit) {
             await shouldSkipRequest();
-            return handler(event, ws, options);
+            return handler(c, event, ws, options);
           }
 
           try {


### PR DESCRIPTION
Since the limiter is defined above the controller, there's not a convenient way to access the Hono context unless we pass it in. I need it in the `skip` function, but it seems reasonable that it should be passed into the handler as well.