### PR TITLE
Fix Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ app.get(
 
 `hono-rate-limiter` supports external data stores to synchronize hit counts across multiple processes and servers.
 
-By default, `MemoryStore` is used. This one does not synchronize its state across instances. It’s simple to deploy, and often sufficient for basic abuse prevention, but will be inconnsistent across reboots or in deployments with multiple process or servers.
+By default, `MemoryStore` is used. This one does not synchronize its state across instances. It’s simple to deploy, and often sufficient for basic abuse prevention, but will be inconsistent across reboots or in deployments with multiple process or servers.
 
 Deployments requiring more consistently enforced rate limits should use an external store.
 


### PR DESCRIPTION
Just fixing a small typo in the README file. 

No actual code change.