### PR TITLE
fix(KVStore.ts) : ensure expirations always meet Cloudflare's 60s minimum requirement and being integers

### DIFF
--- a/packages/cloudflare/src/stores/KVStore.ts
+++ b/packages/cloudflare/src/stores/KVStore.ts
@@ -100,7 +100,7 @@ export class WorkersKVStore<
     }
 
     await this.namespace.put(this.prefixKey(key), JSON.stringify(payload), {
-      expiration: payload.resetTime.getTime() / 1000,
+      expiration: Math.floor(payload.resetTime.getTime() / 1000) + 60, // meets Cloudflare's 60-second minimum requirement
     });
 
     return payload;
@@ -119,7 +119,7 @@ export class WorkersKVStore<
     payload.totalHits -= 1;
 
     await this.namespace.put(this.prefixKey(key), JSON.stringify(payload), {
-      expiration: Math.floor(payload.resetTime.getTime() / 1000),
+      expiration: Math.floor(payload.resetTime.getTime() / 1000) + 60, // meets Cloudflare's 60-second minimum requirement
     });
   }
 


### PR DESCRIPTION
# Fix KV Store Expiration Time Handling

## Problem
The current implementation has two issues with KV expiration times:

1. Inconsistent handling between methods:
   - [increment](cci:1://file:///c:/Users/pl101/Desktop/llml.ai/workers/llm-crawler/src/middleware/rate-limiter.ts:25:1-75:2): Uses floating-point timestamp (`resetTime.getTime() / 1000`)
   - `decrementToken`: Uses integer timestamp (`Math.floor(resetTime.getTime() / 1000)`)

2. Does not guarantee Cloudflare's requirement of expiration being at least 60 seconds in the future, which can lead to KV PUT failures with error: "Invalid expiration. Expiration times must be at least 60 seconds in the future."

![Screenshot 2024-12-16 175409](https://github.com/user-attachments/assets/93c5483a-81af-42bb-b415-2b5407a2d95c)

## Solution
1. Make expiration time handling consistent across methods
2. Add 60-second buffer to ensure KV entries:
   - Meet Cloudflare's minimum requirement
   - Exist for the entire rate limit window
   - Have proper cleanup after window ends

### Changes
```diff
// In increment method
- expiration: payload.resetTime.getTime() / 1000
+ expiration: Math.floor(payload.resetTime.getTime() / 1000) + 60

// In decrementToken method
- expiration: Math.floor(payload.resetTime.getTime() / 1000)
+ expiration: Math.floor(payload.resetTime.getTime() / 1000) + 60
```

### Benefits
Prevents KV PUT failures due to invalid expiration times
1. Ensures rate limit state is maintained correctly throughout the window
2. Uses consistent integer timestamps across all KV operations
4. Provides proper cleanup timing after rate limit windows end

### Testing
Tested with various rate limit configurations:
- Short windows (10 seconds)
- Long windows (1 minute)
- Multiple concurrent requests
- Requests near window boundaries