### PR TITLE
fix(KVStore): resolve KVStore time window and expiration issues

### DIFF
--- a/packages/cloudflare/src/stores/KVStore.ts
+++ b/packages/cloudflare/src/stores/KVStore.ts
@@ -13,6 +13,14 @@ export class WorkersKVStore<
 > implements Store<E, P, I>
 {
   /**
+   * Expiration targets that are less than 60 seconds into the future are not supported. This is true for both expiration methods.
+   *
+   * see: https://developers.cloudflare.com/kv/api/write-key-value-pairs/#expiring-keys
+   *
+   */
+  private static readonly KV_MIN_EXPIRATION_BUFFER = 60;
+
+  /**
    * The text to prepend to the key in Redis.
    */
   prefix: string;
@@ -76,51 +84,63 @@ export class WorkersKVStore<
   }
 
   /**
-   * Method to increment a client's hit counter.
+   * Method to increment a client's hit counter. If the current time is within an active window,
+   * it increments the existing hit count. Otherwise, it starts a new window with a hit count of 1.
    *
    * @param key {string} - The identifier for a client
    *
-   * @returns {ClientRateLimitInfo} - The number of hits and reset time for that client
+   * @returns {ClientRateLimitInfo} - An object containing:
+   *   - totalHits: The updated number of hits for the client
+   *   - resetTime: The time when the current rate limit window expires
    */
   async increment(key: string): Promise<ClientRateLimitInfo> {
-    let payload = {
-      totalHits: 1,
-      resetTime: new Date(Date.now() + this.windowMs),
+    const nowMS = Date.now();
+    const record = await this.get(key);
+    const defaultResetTime = new Date(nowMS + this.windowMs);
+
+    const existingResetTimeMS =
+      record?.resetTime && new Date(record.resetTime).getTime();
+    const isActiveWindow = existingResetTimeMS && existingResetTimeMS > nowMS;
+
+    const payload: ClientRateLimitInfo = {
+      totalHits: isActiveWindow ? record.totalHits + 1 : 1,
+      resetTime:
+        isActiveWindow && existingResetTimeMS
+          ? new Date(existingResetTimeMS)
+          : defaultResetTime,
     };
 
-    const record = await this.get(key);
-
-    if (record) {
-      payload = {
-        totalHits: record.totalHits + 1,
-        resetTime: record.resetTime
-          ? new Date(record.resetTime)
-          : payload.resetTime,
-      };
-    }
-
-    await this.namespace.put(this.prefixKey(key), JSON.stringify(payload), {
-      expiration: payload.resetTime.getTime() / 1000,
-    });
+    await this.updateRecord(key, payload);
 
     return payload;
   }
 
   /**
-   * Method to decrement a client's hit counter.
+   * Method to decrement a client's hit counter. Only decrements if there is an active time window.
+   * The hit counter will never go below 0.
    *
    * @param key {string} - The identifier for a client
+   * @returns {Promise<void>} - Returns void after attempting to decrement the counter
    */
   async decrement(key: string): Promise<void> {
-    const payload = await this.get(key);
+    const nowMS = Date.now();
+    const record = await this.get(key);
 
-    if (!payload || !payload.resetTime) return;
+    const existingResetTimeMS =
+      record?.resetTime && new Date(record.resetTime).getTime();
+    const isActiveWindow = existingResetTimeMS && existingResetTimeMS > nowMS;
 
-    payload.totalHits -= 1;
+    // Only decrement if in active window
+    if (isActiveWindow && record) {
+      const payload: ClientRateLimitInfo = {
+        totalHits: Math.max(0, record.totalHits - 1), // Never go below 0
+        resetTime: new Date(existingResetTimeMS),
+      };
 
-    await this.namespace.put(this.prefixKey(key), JSON.stringify(payload), {
-      expiration: Math.floor(payload.resetTime.getTime() / 1000),
-    });
+      await this.updateRecord(key, payload);
+    }
+
+    return;
   }
 
   /**
@@ -130,5 +150,39 @@ export class WorkersKVStore<
    */
   async resetKey(key: string): Promise<void> {
     await this.namespace.delete(this.prefixKey(key));
+  }
+
+  /**
+   * Method to calculate expiration.
+   *
+   * @param resetTime {Date} - The reset time.
+   *
+   * @returns {number} - The expiration in seconds.
+   *
+   * Note: KV expiration is always set to 60s after resetTime or nowSeconds to meet Cloudflare's minimum requirement.
+   * This doesn't affect rate limiting behavior which is controlled by resetTime.
+   */
+  private calculateExpiration(resetTime: Date): number {
+    const resetTimeSeconds = Math.floor(resetTime.getTime() / 1000);
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    return Math.max(
+      resetTimeSeconds + WorkersKVStore.KV_MIN_EXPIRATION_BUFFER,
+      nowSeconds + WorkersKVStore.KV_MIN_EXPIRATION_BUFFER,
+    );
+  }
+
+  /**
+   * Method to update a record.
+   *
+   * @param key {string} - The identifier for a client.
+   * @param payload {ClientRateLimitInfo} - The payload to update.
+   */
+  private async updateRecord(
+    key: string,
+    payload: ClientRateLimitInfo,
+  ): Promise<void> {
+    await this.namespace.put(this.prefixKey(key), JSON.stringify(payload), {
+      expiration: this.calculateExpiration(payload.resetTime as Date),
+    });
   }
 }

--- a/packages/cloudflare/src/stores/KVStore.ts
+++ b/packages/cloudflare/src/stores/KVStore.ts
@@ -165,9 +165,9 @@ export class WorkersKVStore<
   private calculateExpiration(resetTime: Date): number {
     const resetTimeSeconds = Math.floor(resetTime.getTime() / 1000);
     const nowSeconds = Math.floor(Date.now() / 1000);
-    return Math.max(
-      resetTimeSeconds + WorkersKVStore.KV_MIN_EXPIRATION_BUFFER,
-      nowSeconds + WorkersKVStore.KV_MIN_EXPIRATION_BUFFER,
+    return (
+      Math.max(resetTimeSeconds, nowSeconds) +
+      WorkersKVStore.KV_MIN_EXPIRATION_BUFFER
     );
   }
 


### PR DESCRIPTION
# Fixed KV Store Rate Limiter Implementation

- Fix increment/decrement methods to properly handle active time windows
- Add KV_MIN_EXPIRATION_BUFFER to enforce Cloudflare's 60s minimum requirement
- Extract updateRecord method to ensure consistent KV updates
- Add calculateExpiration helper to handle expiration times correctly
- Prevent totalHits from going below 0 in decrement method
- Update docstrings with accurate behavior descriptions

## Problems
The original implementation had two key issues with Cloudflare KV time handling:
1. KV expiration was set equal to the rate limit window's reset time
2. This might violate Cloudflare's requirement that KV expiration must be at least 60 seconds in the future

![Screenshot 2024-12-16 175409](https://github.com/user-attachments/assets/2ec23408-0dc2-4c27-80b2-997750129981)

Example of error ❌
It might work for the first request with ANY window > 60s, but it fails for late requests in ANY window size when:
```ts
(resetTime - currentTime) < 60 seconds
```

```ts
// Original code issue example
// User makes first request at 16:58:58
const nowMS = Date.now();  // 16:58:58
const windowMs = 60000;    // 1-minute window

let payload = {
    totalHits: 1,
    resetTime: new Date(nowMS + windowMs)  // 16:59:58 (window end)
};

// KV expiration is set to:
expiration: payload.resetTime.getTime() / 1000  // 16:59:58 

// User makes another request at 16:59:40 (42s into window)
const record = await this.get(key);  // Gets existing record
payload = {
    totalHits: record.totalHits + 1,
    resetTime: new Date(record.resetTime)  // Still 16:59:58
};

// KV expiration is set to:
expiration: payload.resetTime.getTime() / 1000  // 16:59:58 ❌
// Only 18s in future! Violates Cloudflare's 60s minimum

```

Visual Timeline:

```
16:58:58 -------- 16:59:40 -- 16:59:58
[First Req]      [Late Req]  [Window End/KV Expires]
     |               |            |
     |<------ 1-minute window -->|
                    |<- Only 18s ->| ❌ Too short!
```

## Solution
Enhanced the KVStore implementation to properly handle both rate limiting windows and KV expiration:

1. **Separated Concerns**
   - Rate limit window: Controls when users can make new requests
   - KV expiration: Ensures data storage meets Cloudflare's requirements

2. **Window Management**
   ```typescript
   const nowMS = Date.now();
   const existingResetTimeMS = record?.resetTime && new Date(record.resetTime).getTime();
   const isActiveWindow = existingResetTimeMS && existingResetTimeMS > nowMS;

The fix ensures:
  ```ts
  // For the same late request at 16:59:40
  const expirationSeconds = Math.max(
      resetTimeSeconds + 60,  // 17:00:58
      nowSeconds + 60        // 17:00:40
  );
  // Uses 17:00:58 ✅ Always at least 60s in future
  ```
  
Another case where nowSeconds + 60 is used:
```ts
// Example: 5-minute window (300s), and 5 limits 
const windowMs = 300000;  // 5 minutes

// User makes 1st request at 17:04:51, valid hit 1/5 🎯
const nowMS = Date.now();                    // 17:04:51
const defaultResetTime = nowMS + windowMs;   // 17:09:51 (window ends)
const expirationSeconds = Math.max(
    resetTimeSeconds + 60,  // 17:10:51 ✅ used (later)
    nowSeconds + 60        // 17:05:51
);

// Now at 17:09:30 (21s before window ends)
// User makes 2nd request, valid hit 2/5 🎯
nowMS = Date.now();                         // 17:09:30
resetTimeSeconds = 17:09:51                 // Original window ends
const expirationSeconds = Math.max(
    resetTimeSeconds + 60,  // 17:10:51 ✅ still used (later)
    nowSeconds + 60        // 17:10:30
);
// Still uses resetTimeSeconds + 60 because it's later

// BUT! At 17:09:52 (5s after window ends)
// User makes 3rd request, still valid hit 3/5 🎯
nowMS = Date.now();                         // 17:09:55
resetTimeSeconds = 17:09:51                 // old window that just ended
const expirationSeconds = Math.max(
    resetTimeSeconds + 60,  // 17:10:51
    nowSeconds + 60        // 17:10:55 ✅ used instead because it's later, and still compliant with the min-60s rule
);
```
   
## Benefits
✅ Compliant with Cloudflare's 60-second minimum expiration requirement
✅ Accurate rate limiting for any window duration (even < 60s)
✅ Clean separation between rate limiting logic and KV storage requirements
✅ Improved code organization with helper methods
✅ Better type safety and error handling

## Testing
Works correctly for all window durations:
 - Short windows (< 60s)
 - Equal windows (60s)
 - Long windows (> 60s)