### PR TITLE
fix: Handle object response from unstorage

### DIFF
--- a/src/stores/unstorage.ts
+++ b/src/stores/unstorage.ts
@@ -68,9 +68,13 @@ export class UnstorageStore<
   async get(key: string): Promise<ClientRateLimitInfo | undefined> {
     const result = await this.storage
       .get(this.prefixKey(key))
-      .then((value) =>
-        value ? (JSON.parse(String(value)) as ClientRateLimitInfo) : undefined,
-      );
+      .then((value) => {
+        if (typeof value === 'object') {
+          return value as ClientRateLimitInfo;
+        }
+        
+        return value ? JSON.parse(String(value)) as ClientRateLimitInfo : undefined;
+      });
 
     return result;
   }


### PR DESCRIPTION
Was trying out the new unstorage adapter for redis and found that it was returning the json as an object which casting to a string was causing it to become object Object. Instead, treat objects as the json response.